### PR TITLE
Matching request fix

### DIFF
--- a/SubletNU/src/components/AlertModal.jsx
+++ b/SubletNU/src/components/AlertModal.jsx
@@ -1,0 +1,17 @@
+import React from "react";
+import "../css/createList.css";
+
+const AlertModal = ({isOpen, onClose, message}) => {
+    if (!isOpen) return null;
+
+    return(
+        <div className="modal-overlay">
+            <div className="modal-box">
+                <button className="modal-close" onClick={onClose}>×</button>
+                <p>{message}</p>
+            </div>
+            </div>
+    );
+};
+
+export default AlertModal;

--- a/SubletNU/src/components/CreateListingModel.jsx
+++ b/SubletNU/src/components/CreateListingModel.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 import { db, auth } from "../firebase";
 import { ref, push, update, child } from "firebase/database";
 import "../css/createList.css";
@@ -13,6 +13,7 @@ export default function CreateListingModal({ isOpen, onClose }) {
   const [endDate, setEndDate] = useState("");
 
   if (!isOpen) return null; // 👈 不显示时返回 null
+
 
   const handleLocationChange = (e) => {
     const currLocation = e.target.value;

--- a/SubletNU/src/components/CreateListingModel.jsx
+++ b/SubletNU/src/components/CreateListingModel.jsx
@@ -16,7 +16,8 @@ export default function CreateListingModal({ isOpen, onClose }) {
 
   const handleLocationChange = (e) => {
     const currLocation = e.target.value;
-    const addressRegex = /^[0-9]+\s[A-Za-z0-9\s]+\s[A-Za-z\s]+\s[A-Za-z]{2}\s[0-9]{5}$/;
+    // const addressRegex = /^[0-9]+\s[A-Za-z0-9\s]+\s[A-Za-z\s]+\s[A-Za-z]{2}\s[0-9]{5}$/;
+    const addressRegex = /^\d+\s+[\w\s.]+,?\s+[\w\s.]+,?\s+[A-Z]{2}\s+\d{5}$/;
     setLocation(currLocation);
     setIsLocValid(addressRegex.test(currLocation));
   };
@@ -24,7 +25,7 @@ export default function CreateListingModal({ isOpen, onClose }) {
   const handleSubmit = async (e) => {
     e.preventDefault();
     if (!isLocValid) {
-      setLocation("");
+      // setLocation("");
       alert("Please enter a valid address (e.g. 633 Clark St Evanston IL 60208)");
       return;
     }
@@ -87,7 +88,7 @@ export default function CreateListingModal({ isOpen, onClose }) {
           <input type="date" value={endDate} onChange={(e) => setEndDate(e.target.value)} min={startDate} required />
           <textarea placeholder="Description" value={description} onChange={(e) => setDescription(e.target.value)} required />
           <input type="text" placeholder="633 Clark St Evanston IL 60208" value={location} onChange={handleLocationChange} required />
-          <input type="number" placeholder="Price" value={price} onChange={(e) => setPrice(e.target.value)} required />
+          <input type="number" placeholder="Price" value={price} min="0" onChange={(e) => setPrice(e.target.value)} required />
           <button type="submit">Post Listing</button>
         </form>
       </div>

--- a/SubletNU/src/components/LeafletMapBox.jsx
+++ b/SubletNU/src/components/LeafletMapBox.jsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from "react";
-import { MapContainer, TileLayer, Marker, Popup } from "react-leaflet";
+import { MapContainer, TileLayer, Marker, Popup, useMapEvents } from "react-leaflet";
 import "leaflet/dist/leaflet.css";
 import L from "leaflet";
 
@@ -23,8 +23,18 @@ const center = {
   lng: -87.675171,
 };
 
-export default function LeafletMapBox({ listings }) {
+export default function LeafletMapBox({ setSelectedMarker, listings }) {
   const [markers, setMarkers] = useState([]);
+  const [selected, setSelected] = useState({}); // the marker object
+
+  const handleMarkerClick = (marker) => {
+    try {
+      setSelectedMarker(marker);
+      setSelected(marker);
+    } catch (error) {
+      console.error("Map click error:", error);
+    }
+  };
 
   useEffect(() => {
     const fetchCoordinates = async () => {
@@ -70,12 +80,16 @@ export default function LeafletMapBox({ listings }) {
       />
 
       {markers.map((marker, index) => (
-        <Marker key={index} position={[marker.lat, marker.lng]}>
+        <Marker 
+          key={index} 
+          position={[marker.lat, marker.lng]}
+          >
           <Popup>
             <strong>{marker.title || "Untitled"}</strong><br />
             {marker.location}<br />
             {marker.startDate} → {marker.endDate}<br />
-            <strong>${marker.price}/month</strong>
+            <strong>${marker.price}/month</strong><br />
+            <button onClick={() => setSelectedMarker(marker)}>Read More</button>
           </Popup>
         </Marker>
       ))}

--- a/SubletNU/src/css/Sidebar.css
+++ b/SubletNU/src/css/Sidebar.css
@@ -31,6 +31,10 @@
   background-color: #e5e7eb;
 }
 
+.sidebar button:focus {
+  background-color: #cccdcf;
+}
+
 /* 小屏优化：小于 1000px 或竖屏时横排展示 */
 @media (max-width: 1000px), (orientation: portrait) {
   .page-container {

--- a/SubletNU/src/pages/HomePage.jsx
+++ b/SubletNU/src/pages/HomePage.jsx
@@ -3,6 +3,7 @@ import { useNavigate } from "react-router-dom";
 import Listing from "../components/Listing";
 import PageWrapper from "../components/PageWrapper";
 import CreateListingModal from "../components/CreateListingModel";
+import AlertModal from "../components/AlertModal";
 import LeafletMapBox from "../components/LeafletMapBox";
 import { db } from "../firebase";
 import { ref, get } from "firebase/database"; // ✅ 使用 get 而非 onValue
@@ -15,6 +16,8 @@ export default function HomePage() {
   const [showAllListings, setShowAllListings] = useState(true);
   const [showUserListings, setShowUserListings] = useState(false);
   const [isCreateOpen, setIsCreateOpen] = useState(false);
+  const [isAlertOpen, setAlertModal] = useState(false);
+  const [alertModalMessage, setAlertModalMessage] = useState("");
   const [selectedMarker, setSelectedMarker] = useState({}); 
   // ^to be used for filtering so user can see the listing they've just selected
 
@@ -58,6 +61,11 @@ export default function HomePage() {
     fetchListings(); // ✅ 只执行一次
   }, []);
 
+  const onAlertClose = () => {
+    setAlertModal(false);
+    setAlertModalMessage("");
+  };
+
   return (
     <PageWrapper
       onShowAll={() => {
@@ -82,13 +90,15 @@ export default function HomePage() {
           />
 
           {showAllListings && (
-            <Listing setListings={setListings} />
+            <Listing setListings={setListings} setAlertModal={setAlertModal} setAlertModalMessage={setAlertModalMessage}/>
           )}
 
           {showUserListings && (
-            <Listing setListings={setListings} showOnlyCurrentUser={true} />
+            <Listing setListings={setListings} setAlertModal={setAlertModal} setAlertModalMessage={setAlertModalMessage} showOnlyCurrentUser={true} />
           )}
+        
         </div>
+
 
         <div className="home-map-container">
 
@@ -107,6 +117,12 @@ export default function HomePage() {
       <CreateListingModal
         isOpen={isCreateOpen}
         onClose={() => setIsCreateOpen(false)}
+      />
+
+      <AlertModal 
+        isOpen={isAlertOpen} 
+        onClose={() => onAlertClose()} 
+        message={alertModalMessage}
       />
     </PageWrapper>
   );

--- a/SubletNU/src/pages/HomePage.jsx
+++ b/SubletNU/src/pages/HomePage.jsx
@@ -15,11 +15,17 @@ export default function HomePage() {
   const [showAllListings, setShowAllListings] = useState(true);
   const [showUserListings, setShowUserListings] = useState(false);
   const [isCreateOpen, setIsCreateOpen] = useState(false);
+  const [selectedMarker, setSelectedMarker] = useState({}); 
+  // ^to be used for filtering so user can see the listing they've just selected
 
   const filteredListings = listings.filter(
     (listing) =>
       listing.location?.toLowerCase().includes(filter.toLowerCase())
   );
+
+  useEffect(() => {
+    console.log("Home page selected marker:", selectedMarker);
+  },[selectedMarker]);
 
   useEffect(() => {
     const fetchListings = async () => {
@@ -90,9 +96,9 @@ export default function HomePage() {
 
 
           <LeafletMapBox
+            setSelectedMarker={setSelectedMarker}
             listings={mapMarkers.filter((l) =>
               l.location?.toLowerCase().includes(filter.toLowerCase())
-
             )}
           />
         </div>

--- a/SubletNU/src/pages/ProfilePage.jsx
+++ b/SubletNU/src/pages/ProfilePage.jsx
@@ -141,12 +141,12 @@ export default function ProfilePage() {
               {match.owner === auth.currentUser.uid ? (
                 <>
                   <p>You matched with {match.requester} for listing {match.listingId}</p>
-                  <button onClick={() => handleContactOwner(match, false)}>Contact</button>
+                  <button onClick={() => handleContactOwner(match, true)}>Contact</button>
                 </>
               ) : (
                 <>
                   <p>Owner of listing {match.listingId} accepted your match</p>
-                  <button onClick={() => handleContactOwner(match, true)}>Contact</button>
+                  <button onClick={() => handleContactOwner(match, false)}>Contact</button>
                 </>
               )}
             </li>

--- a/SubletNU/src/pages/ProfilePage.jsx
+++ b/SubletNU/src/pages/ProfilePage.jsx
@@ -2,15 +2,13 @@ import React, { useState, useEffect } from "react";
 import { db, auth } from "../firebase";
 import {
   ref,
-  remove,
   push,
   update,
-  onValue,
   get,
-  onChildAdded,
-  onChildRemoved,
+  onChildAdded
 } from "firebase/database";
 import CreateListingModal from "../components/CreateListingModel";
+import AlertModal from "../components/AlertModal";
 import PageWrapper from "../components/PageWrapper";
 import "../css/profile.css";
 
@@ -19,89 +17,128 @@ export default function ProfilePage() {
   const [matchRequestsIds, setRequestIds] = useState([]);
   const [matches, setMatches] = useState([]);
   const [isCreateOpen, setIsCreateOpen] = useState(false);
+  const [isAlertOpen, setAlertModal] = useState(false);
+  const [alertModalMessage, setAlertModalMessage] = useState("");
 
   const dbMatchReqRef = ref(db, "users/" + auth.currentUser.uid + "/userMatchRequests");
   const dbMatchesRef = ref(db, "users/" + auth.currentUser.uid + "/userMatches");
 
-  useEffect(() => {
-    return onChildAdded(dbMatchReqRef, (snapshot) => {
-      const data = snapshot.val();
-      if (!matchRequestsIds.includes(data)) {
-        setRequestIds((prev) => [...prev, data]);
-        const dbRef = ref(db, "matches/" + data);
-        onValue(dbRef, (snap) => {
-          if (snap.val()) setRequests((prev) => [...prev, snap.val()]);
-        });
-      }
-    });
-  }, [dbMatchReqRef]);
 
+  // render profile page with matches and then listen for added and rmeoved children
   useEffect(() => {
-    return onChildRemoved(dbMatchReqRef, (snapshot) => {
-      const data = snapshot.val();
-      if (data) {
-        setRequestIds((prev) => prev.filter((item) => item !== data.key));
-        setRequests((prev) => prev.filter((item) => item.key !== data.key));
-      }
-    });
-  }, [dbMatchReqRef]);
+    let unsubscribeReqAdded = null;
+    let unsubscribeMatchAdded = null;
 
-  useEffect(() => {
-    return onChildAdded(dbMatchesRef, (snapshot) => {
-      const data = snapshot.val();
-      if (!data) return;
-      const dbRef = ref(db, "matches/" + data);
-      onValue(dbRef, (snap) => {
-        if (snap.val()) {
-          const alreadyIn = matches.find((m) => m.key === data);
-          if (!alreadyIn) setMatches((prev) => [...prev, snap.val()]);
+    // listen for added match Requests
+    try {
+      unsubscribeReqAdded = onChildAdded(dbMatchReqRef, (snapshot) => {
+        const data = snapshot.key; // the match key 
+
+        // add all request ids that are not duplicates
+
+        if (!matchRequestsIds.includes(data)){
+          setRequestIds((prev) => [...prev, data]);
+
+          // get corresponding match id
+          const matchRef = ref(db, "matches/" + data);
+          get(matchRef).then((snap) => {
+            if (snap.exists()){
+              const dbMatch = snap.val();
+              setRequests((prev) => {
+                const matchExists = prev.some((match) => match.key == dbMatch.key);
+                if (!matchExists) return [...prev, dbMatch];
+                return prev;
+              });
+              
+            }
+          });
         }
+
       });
-    });
-  }, [dbMatchesRef]);
+    } catch (err) {
+      console.error("Error onChildAdded for adding a new match req:", err);
+    }
+
+
+    // listen for new matches added
+    try {
+      unsubscribeMatchAdded = onChildAdded(dbMatchesRef, (snapshot) => {
+        const data = snapshot.key; // new match key 
+        if (!data) return;
+        
+        const dbRef = ref(db, "matches/" + data);
+        get(dbRef).then((snap) => {
+          if (snap.val()) { // snap.val() is the match
+            setMatches((prev) => {
+              const alreadyIn = prev.find((m) => m.key === data); //data is the new match key
+              if (!alreadyIn) return [...prev, snap.val()];
+              return prev;
+            });
+          }
+        });
+        
+      });
+    } catch (err) {
+      console.error("Error onChildAdded for match data:", err);
+    }
+    
+
+    // unsubscribe to all listeners
+    return () => {
+      if (unsubscribeReqAdded) unsubscribeReqAdded();
+      if (unsubscribeMatchAdded) unsubscribeMatchAdded();
+    }  
+
+  }, [dbMatchReqRef, dbMatchesRef]); //on any change in the matches and match requests
+
+
+  useEffect(() => {
+    console.log("matches curr:",matches);
+    console.log("requests curr:",matchRequests);
+
+  }, [matches, matchRequests]);
+
+
 
   const handleApproveMatch = async (matchObj) => {
     update(ref(db, "matches/" + matchObj.key), { approved: "true" });
 
-    const ownerPath = "users/" + matchObj.owner + "/userMatchRequests";
-    const requesterPath = "users/" + matchObj.requester + "/userMatchRequests";
+    const ownerPath = "users/" + matchObj.owner + "/userMatchRequests/" + matchObj.key;
+    const requesterPath = "users/" + matchObj.requester + "/userMatchRequests/" + matchObj.key;
 
-    const [snapOwner, snapRequester] = await Promise.all([
-      get(ref(db, ownerPath)),
-      get(ref(db, requesterPath)),
-    ]);
-
-    const removeKey = (obj, key) => {
-      if (!obj) return {};
-      const index = Object.values(obj).indexOf(key);
-      return index !== -1 ? { [index]: null } : {};
-    };
-
-    await update(ref(db), {
-      [ownerPath]: removeKey(snapOwner.val(), matchObj.key),
-      [requesterPath]: removeKey(snapRequester.val(), matchObj.key),
+    await update(ref(db),{
+      [ownerPath]: null,
+      [requesterPath]: null
     });
 
+    // add approved match to the requester and owner
     await updateMatch(matchObj);
     setMatches((prev) => [...prev, matchObj]);
     setRequestIds((prev) => prev.filter((item) => item !== matchObj.key));
     setRequests((prev) => prev.filter((item) => item.key !== matchObj.key));
-    alert("Match Approved. Email sent.");
+
+    setAlertModalMessage("Match Approved. Email sent.");
+    setAlertModal(true);
   };
 
   const updateMatch = async (matchObj) => {
     await update(ref(db), {
-      ["users/" + matchObj.owner + "/userMatches"]: push(ref(db)).key,
-      ["users/" + matchObj.requester + "/userMatches"]: push(ref(db)).key,
+      ["users/" + matchObj.owner + "/userMatches/" + matchObj.key]: matchObj.listingId,
+      ["users/" + matchObj.requester + "/userMatches/" + matchObj.key]: matchObj.listingId
     });
   };
 
   const handleContactOwner = (match, isOwner) => {
-    alert(
-      isOwner
-        ? "Here is your sublet requester's email: " + match.requesterContact
-        : "Here is the sublet owner's email: " + match.ownerContact
-    );
+    let message = "";
+    isOwner ? message = "Here is your sublet requester's email: " + match.requesterContact
+      : message = "Here is the sublet owner's email: " + match.ownerContact;
+    setAlertModalMessage(message);
+    setAlertModal(true);
+  };
+
+  const onAlertClose = () => {
+    setAlertModal(false);
+    setAlertModalMessage("");
   };
 
   return (
@@ -113,50 +150,75 @@ export default function ProfilePage() {
       <h2 className="profile-title">Your Profile</h2>
       <p className="profile-email">Email: {auth.currentUser.email}</p>
 
-      <h3>Open Match Requests</h3>
-      {matchRequests.length > 0 ? (
+      <h2>Your Listings Matches</h2>
+      <h3>Pending</h3>
+      
+      {matchRequests.filter((match) => match.owner === auth.currentUser.uid).length > 0 ? (
         <ul>
           {matchRequests.map((match) => (
             <li key={match.key}>
-              {match.owner !== auth.currentUser.uid ? (
-                <p>Waiting on owner's response for listing {match.listingId}</p>
-              ) : (
+              {match.owner === auth.currentUser.uid ? (
                 <>
-                  <p>User {match.requester} wants to sublet your listing {match.listingId}</p>
+                  <p>User {match.requester} wants to sublet your listing "{match.listingTitle}" at {match.listingLoc}</p>
                   <button onClick={() => handleApproveMatch(match)}>Approve</button>
                 </>
-              )}
+              ) : null}
             </li>
           ))}
         </ul>
-      ) : (
-        <p>No match requests</p>
-      )}
+      ) : (<p>No pending match requests</p>)}
 
-      <h3>Responses/Matches</h3>
-      {matches.length > 0 ? (
+      <h3>Approved</h3>
+      {matches.filter((match) => match.owner === auth.currentUser.uid).length > 0 ? (
         <ul>
           {matches.map((match) => (
             <li key={match.key}>
               {match.owner === auth.currentUser.uid ? (
                 <>
-                  <p>You matched with {match.requester} for listing {match.listingId}</p>
+                  <p>You have approved a matching with {match.requester} for listing "{match.listingTitle}" at {match.listingLoc}</p>
                   <button onClick={() => handleContactOwner(match, true)}>Contact</button>
                 </>
-              ) : (
-                <>
-                  <p>Owner of listing {match.listingId} accepted your match</p>
-                  <button onClick={() => handleContactOwner(match, false)}>Contact</button>
-                </>
-              )}
+              ) : null}
             </li>
           ))}
         </ul>
-      ) : (
-        <p>No matches</p>
-      )}
+      ) : (<p>No approved match requests</p>)}
+
+
+
+      <h2>Your Match Request Status</h2>
+      <h3>Pending</h3>
+      {matchRequests.filter((match) => match.requester === auth.currentUser.uid).length > 0 ? (
+        <ul>
+          {matchRequests.map((match) => (
+            <li key={match.key}>
+              {match.requester === auth.currentUser.uid ? (
+                <p>Waiting on sublet owner's response for listing "{match.listingTitle}" at {match.listingLoc}</p>
+              ) : null}
+            </li>
+          ))}
+        </ul>
+      ) : (<p>No pending match requests</p>)}
+
+      <h3>Approved</h3>
+      {matches.filter((match) => match.requester === auth.currentUser.uid).length > 0 ? (
+        <ul>
+          {matches.map((match) => (
+            <li key={match.key}>
+              {match.requester === auth.currentUser.uid ? (
+                <>
+                  <p>Owner of listing "{match.listingTitle}" at {match.listingLoc} accepted your match</p>
+                  <button onClick={() => handleContactOwner(match, false)}>Contact</button>
+                </>
+              ) : null}
+            </li>
+          ))}
+        </ul>
+      ) : (<p>No approved match requests</p>)}
+
 
       <CreateListingModal isOpen={isCreateOpen} onClose={() => setIsCreateOpen(false)} />
+      <AlertModal isOpen={isAlertOpen} onClose={() => onAlertClose()} message={alertModalMessage}/>
     </PageWrapper>
   );
 }


### PR DESCRIPTION
Updated profile page so matches are sorted under user owned and non-user owned. Added duplicate checking to match request so it won't allow duplicate requests if use has already made a request for or matched with that listing). Match contact now shows correct contact information. And in database under users, matches and match requests are saved as "matchkey: its corresponding listingId"